### PR TITLE
Reduce amount of headers that need to be fetched during initial import

### DIFF
--- a/src/Spottarr.Console/Program.cs
+++ b/src/Spottarr.Console/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Spottarr.Data.Helpers;
 using Spottarr.Services;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -8,5 +9,7 @@ builder.Logging.AddConsole();
 builder.Services.AddSpottarrServices(builder.Configuration, true);
 
 var app = builder.Build();
+
+await app.MigrateDatabase();
 
 await app.RunAsync();

--- a/src/Spottarr.Data/Helpers/HostExtensions.cs
+++ b/src/Spottarr.Data/Helpers/HostExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Spottarr.Data.Logging;
+
+namespace Spottarr.Data.Helpers;
+
+public static class HostExtensions
+{
+    public static async Task MigrateDatabase(this IHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        await using var scope = host.Services.CreateAsyncScope();
+
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<IHost>>();
+        logger.DatabaseMigrationStarted(DbPathHelper.GetDbPath());
+        var dbContext = scope.ServiceProvider.GetRequiredService<SpottarrDbContext>();
+        await dbContext.Database.MigrateAsync();
+        logger.DatabaseMigrationFinished();
+    }
+}

--- a/src/Spottarr.Data/Logging/LoggerExtensions.cs
+++ b/src/Spottarr.Data/Logging/LoggerExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Logging;
+
+namespace Spottarr.Data.Logging;
+
+internal static partial class LoggerExtensions
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "Database migration started [{DbPath}].")]
+    public static partial void DatabaseMigrationStarted(this ILogger logger, string dbPath);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Database migration finished.")]
+    public static partial void DatabaseMigrationFinished(this ILogger logger);
+}

--- a/src/Spottarr.Services/Logging/LoggerExtensions.cs
+++ b/src/Spottarr.Services/Logging/LoggerExtensions.cs
@@ -6,20 +6,40 @@ public static partial class LoggerExtensions
 {
     [LoggerMessage(Level = LogLevel.Error, Message = "Could not retrieve spot group '{SpotGroup}'.")]
     public static partial void CouldNotRetrieveSpotGroup(this ILogger logger, Exception exception, string spotGroup);
-    
-    [LoggerMessage(Level = LogLevel.Error, Message = "Could not retrieve spot group '{SpotGroup}': [{Code}] '{Message}'.")]
-    public static partial void CouldNotRetrieveSpotGroup(this ILogger logger, string spotGroup, int code, string message);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Could not retrieve articles for [{From}-{To}]: [{Code}] '{Message}'.")]
-    public static partial void CouldNotRetrieveArticleHeaders(this ILogger logger, long from, long? to, int code, string message);
-    
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Could not retrieve spot group '{SpotGroup}': [{Code}] '{Message}'.")]
+    public static partial void CouldNotRetrieveSpotGroup(this ILogger logger, string spotGroup, int code,
+        string message);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Could not retrieve articles for [{From}-{To}]: [{Code}] '{Message}'.")]
+    public static partial void CouldNotRetrieveArticleHeaders(this ILogger logger, long from, long? to, int code,
+        string message);
+
     [LoggerMessage(Level = LogLevel.Error, Message = "Could not retrieve articles for [{From}-{To}].")]
-    public static partial void CouldNotRetrieveArticleHeaders(this ILogger logger, Exception exception, long from, long? to);
-    
+    public static partial void CouldNotRetrieveArticleHeaders(this ILogger logger, Exception exception, long from,
+        long? to);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Could not retrieve date header for [{ArticleNumber}]: [{Code}] '{Message}'.")]
+    public static partial void CouldNotRetrieveDateHeader(this ILogger logger, long articleNumber, int code,
+        string message);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message =
+            "Found {ArticleNumber} with {ArticleDate} in [{From}-{To}] as closest match for {RetrieveAfterDate} in {Attempts} attempts.")]
+    public static partial void FoundArticleNumberForRetrieveAfter(this ILogger logger, long articleNumber,
+        DateTimeOffset? articleDate, long from, long to, DateTimeOffset retrieveAfterDate, int attempts);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Could not parse date header for [{ArticleNumber}]: '{Error}'.")]
+    public static partial void CouldNotParseDateHeader(this ILogger logger, long articleNumber, string error);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Could not retrieve article [{MessageId}].")]
     public static partial void CouldNotRetrieveArticle(this ILogger logger, Exception exception, string messageId);
-    
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not retrieve article [{MessageId}]: [{Code}] '{Message}'.")]
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Could not retrieve article [{MessageId}]: [{Code}] '{Message}'.")]
     public static partial void CouldNotRetrieveArticle(this ILogger logger, string messageId, int code, string message);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to save spots.")]
@@ -27,53 +47,62 @@ public static partial class LoggerExtensions
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to parse spot header: [{Header}].'")]
     public static partial void FailedToParseSpotHeader(this ILogger logger, string header);
-    
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Article [{MessageId}] is missing spot XML header.'")]
     public static partial void ArticleIsMissingSpotXmlHeader(this ILogger logger, string messageId);
-    
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Article [{MessageId}] contains invalid spot XML header: [{Xml}].'")]
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Article [{MessageId}] contains invalid spot XML header: [{Xml}].'")]
     public static partial void ArticleContainsInvalidSpotXmlHeader(this ILogger logger, string messageId, string xml);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Spot import started at {DateTime}.")]
     public static partial void SpotImportStarted(this ILogger logger, DateTimeOffset dateTime);
-    
-    [LoggerMessage(Level = LogLevel.Information, Message = "Spot import batch ({Current}/{Total}) started at {DateTime}.")]
-    public static partial void SpotImportBatchStarted(this ILogger logger, int current, int total, DateTimeOffset dateTime);
-    
-    [LoggerMessage(Level = LogLevel.Information, Message = "Spot import batch ({Current}/{Total}) finished at {DateTime}. Imported {SpotCount} spots.")]
-    public static partial void SpotImportBatchFinished(this ILogger logger, int current, int total, DateTimeOffset dateTime, int spotCount);
-    
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Spot import batch ({Current}/{Total}) started at {DateTime}.")]
+    public static partial void SpotImportBatchStarted(this ILogger logger, int current, int total,
+        DateTimeOffset dateTime);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Spot import batch ({Current}/{Total}) finished at {DateTime}. Imported {SpotCount} spots.")]
+    public static partial void SpotImportBatchFinished(this ILogger logger, int current, int total,
+        DateTimeOffset dateTime, int spotCount);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Spot import finished at {DateTime}.")]
     public static partial void SpotImportFinished(this ILogger logger, DateTimeOffset dateTime);
-    
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Spot indexing started at {DateTime}.")]
     public static partial void SpotIndexingStarted(this ILogger logger, DateTimeOffset dateTime);
-    
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Spot indexing finished at {DateTime}.")]
     public static partial void SpotIndexingFinished(this ILogger logger, DateTimeOffset dateTime);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Spot indexing batch ({Current}/{Total}) started at {DateTime}.")]
-    public static partial void SpotIndexingBatchStarted(this ILogger logger, int current, int total, DateTimeOffset dateTime);
-    
-    [LoggerMessage(Level = LogLevel.Information, Message = "Spot indexing batch ({Current}/{Total}) finished at {DateTime}. Indexed {SpotCount} spots.")]
-    public static partial void SpotIndexingBatchFinished(this ILogger logger, int current, int total, DateTimeOffset dateTime, int spotCount);
-    
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Spot indexing batch ({Current}/{Total}) started at {DateTime}.")]
+    public static partial void SpotIndexingBatchStarted(this ILogger logger, int current, int total,
+        DateTimeOffset dateTime);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Spot indexing batch ({Current}/{Total}) finished at {DateTime}. Indexed {SpotCount} spots.")]
+    public static partial void SpotIndexingBatchFinished(this ILogger logger, int current, int total,
+        DateTimeOffset dateTime, int spotCount);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Bulk insert / update progress {Percentage}%")]
     public static partial void BulkInsertUpdateProgress(this ILogger logger, decimal percentage);
-    
+
     [LoggerMessage(Level = LogLevel.Debug,
         Message = "Reached retrieve after date {RetrieveAfter}, stopping import.")]
     public static partial void ReachedRetrieveAfter(this ILogger logger, DateTimeOffset retrieveAfter);
-    
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Borrowing NNTP client from pool")]
     public static partial void BorrowingNntpClient(this ILogger logger);
-    
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Returning NNTP client to pool")]
     public static partial void ReturningNntpClient(this ILogger logger);
-    
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Creating new NNTP client ({CurrentPoolSize}/{MaxPoolSize})")]
     public static partial void CreatingNewNntpClient(this ILogger logger, int currentPoolSize, int maxPoolSize);
-    
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Disposing idle NNTP client ({CurrentPoolSize}/{MaxPoolSize})")]
     public static partial void DisposingIdleNntpClient(this ILogger logger, int currentPoolSize, int maxPoolSize);
 }

--- a/src/Spottarr.Services/Parsers/HeaderDateParser.cs
+++ b/src/Spottarr.Services/Parsers/HeaderDateParser.cs
@@ -1,147 +1,19 @@
-using System.Globalization;
-using System.Text.RegularExpressions;
-
 namespace Spottarr.Services.Parsers;
 
-/// <summary>
-/// This class was taken from https://raw.githubusercontent.com/keimpema/Usenet/master/Usenet/Nntp/Parsers/HeaderDateParser.cs
-/// and adjusted to pass analyzer rules
-/// </summary>
-internal static partial class HeaderDateParser
+internal static class HeaderDateParser
 {
-    /// <summary>
-    /// Parses header date/time strings as described in the
-    /// <a href="https://tools.ietf.org/html/rfc5322#section-3.3">Date and Time Specification</a>.
-    /// </summary>
-    /// <param name="value"></param>
-    /// <returns></returns>
     internal static ParserResult<DateTimeOffset> Parse(string value)
     {
-        var valueParts = value.Split([','], StringSplitOptions.RemoveEmptyEntries);
-        if (valueParts.Length > 2)
-            return new ParserResult<DateTimeOffset>("Header date is not in the correct format");
-
-        // skip day-of-week for now
-        //string dayOfWeek = valueParts.Length == 2 ? valueParts[0] : null;
-
-        var dateTime = valueParts.Length == 2 ? valueParts[1] : valueParts[0];
-
-        // remove obsolete whitespace from time part
-        dateTime = DateWhitespaceRegex().Replace(dateTime, ":");
-
-        var dateTimeParts = dateTime.Split([' ', '\n', '\r', '\t'], StringSplitOptions.RemoveEmptyEntries);
-        if (dateTimeParts.Length != 5 && dateTimeParts is not [_, _, _, _, _, "(UTC)"])
-            return new ParserResult<DateTimeOffset>("Header date is not in the correct format");
-
-        var validDate = TryParseDate(dateTimeParts, out var year, out var month, out var day);
-        var validTime = TryParseTime(dateTimeParts[3], out var hour, out var minute, out var second);
-        var validZone = TryParseZone(dateTimeParts[4], out var zone);
-        
-        if(!validDate || !validTime || !validZone)
-            return new ParserResult<DateTimeOffset>("Header date is not in the correct format");
-
-        return new ParserResult<DateTimeOffset>(new DateTimeOffset(year, month, day, hour, minute, second, 0, zone));
-    }
-
-    private static bool TryParseDate(string[] dateTimeParts, out int year, out int month, out int day)
-    {
-        year = 0;
-        month = 0;
-        day = 0;
-        
-        if (dateTimeParts.Length < 3)
-            return false;
-        
-        if (!int.TryParse(dateTimeParts[0], out day))
-            return false;
-        
-        var monthString = dateTimeParts[1];
-        var monthIndex = Array.FindIndex(DateTimeFormatInfo.InvariantInfo.AbbreviatedMonthNames,
-            m => string.Equals(m, monthString, StringComparison.OrdinalIgnoreCase));
-
-        if (monthIndex < 0)
-            return false;
-        
-        month = monthIndex + 1;
-        if (!int.TryParse(dateTimeParts[2], out year))
-            return false;
-        
-        if (dateTimeParts[2].Length <= 2) 
-            year += 100 * GetCentury(year, month, day);
-
-        return true;
-    }
-
-    private static int GetCentury(int year, int month, int day)
-    {
-        var today = DateTime.UtcNow.Date;
-        var currentCentury = today.Year / 100;
-        return new DateTime(currentCentury * 100 + year, month, day, 0, 0, 0, DateTimeKind.Utc) > today
-            ? currentCentury - 1
-            : currentCentury;
-    }
-
-    private static bool TryParseTime(string value, out int hour, out int minute, out int second)
-    {
-        hour = 0;
-        minute = 0;
-        second = 0;
-        
-        var timeParts = value.Split([':'], StringSplitOptions.RemoveEmptyEntries);
-        if (timeParts.Length is < 2 or > 3)
-            return false;
-        
-        if (!int.TryParse(timeParts[0], out hour))
-            return false;
-        
-        if (!int.TryParse(timeParts[1], out minute))
-            return false;
-
-        if (timeParts.Length > 2 && !int.TryParse(timeParts[2], out second))
-            return false;
-
-        return true;
-    }
-
-    private static bool TryParseZone(string value, out TimeSpan result)
-    {
-        // The time zone must be as specified in RFC822, https://tools.ietf.org/html/rfc822#section-5
-        result = TimeSpan.Zero;
-        
-        if (!short.TryParse(value, out var zone) && !TryParseZoneText(value, out zone))
-            return false;
-
-        if (zone is < -9999 or > 9999)
-            return false;
-
-        var minute = zone % 100;
-        var hour = zone / 100;
-        
-        result = TimeSpan.FromMinutes(hour * 60 + minute);
-        return true;
-    }
-
-    private static bool TryParseZoneText(string value, out short zone)
-    {
-        zone = value switch
+        try
         {
-            // UTC is not specified in RFC822, but allowing it since it is commonly used
-            "UTC" or "UT" or "GMT" or "Z" => 0000,
-            "EDT" => -0400,
-            "EST" or "CDT" => -0500,
-            "CST" or "MDT" => -0600,
-            "MST" or "PDT" => -0700,
-            "PST" => -0800,
-            "A" => -0100,
-            "N" => +0100,
-            "M" => -1200,
-            "Y" => +1200,
-            _ => 9999
-        };
-
-        return zone != 9999;
+            var result = Usenet.Nntp.Parsers.HeaderDateParser.Parse(value);
+            return result == null
+                ? new ParserResult<DateTimeOffset>("Header date is not in the correct format")
+                : new ParserResult<DateTimeOffset>(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ParserResult<DateTimeOffset>(ex.Message);
+        }
     }
-
-    [GeneratedRegex(@"\s+:\s+")]
-    private static partial Regex DateWhitespaceRegex();
 }

--- a/src/Spottarr.Services/Parsers/HeaderDateParser.cs
+++ b/src/Spottarr.Services/Parsers/HeaderDateParser.cs
@@ -7,9 +7,9 @@ internal static class HeaderDateParser
         try
         {
             var result = Usenet.Nntp.Parsers.HeaderDateParser.Parse(value);
-            return result == null
-                ? new ParserResult<DateTimeOffset>("Header date is not in the correct format")
-                : new ParserResult<DateTimeOffset>(result);
+            return result != null
+                ? new ParserResult<DateTimeOffset>(result.Value)
+                : new ParserResult<DateTimeOffset>($"Header date '{value}' is not in the correct format");
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Spottarr.Services/SpotImportService.cs
+++ b/src/Spottarr.Services/SpotImportService.cs
@@ -215,6 +215,10 @@ internal sealed class SpotImportService : ISpotImportService
                     // Sometimes articles will just be unavailable
                     // In this case retry the next closest article
                     if (date == null) articleToCheck--;
+
+                    // If no article is available when hitting the low watermark, give up. 
+                    if (articleToCheck < group.LowWaterMark)
+                        throw new InvalidOperationException("No articles available");
                 }
 
                 if (date < options.RetrieveAfter) low = mid + 1;
@@ -228,6 +232,11 @@ internal sealed class SpotImportService : ISpotImportService
             return articleNumber;
         }
         catch (NntpException exception)
+        {
+            _logger.CouldNotRetrieveArticle(exception, string.Empty);
+            return articleNumber;
+        }
+        catch (InvalidOperationException exception)
         {
             _logger.CouldNotRetrieveArticle(exception, string.Empty);
             return articleNumber;

--- a/src/Spottarr.Services/Spottarr.Services.csproj
+++ b/src/Spottarr.Services/Spottarr.Services.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4"/>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4"/>
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
-    <PackageReference Include="Spottarr.Usenet" Version="4.0.1"/>
+    <PackageReference Include="Spottarr.Usenet" Version="4.0.2"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Spottarr.Services/Spottarr.Services.csproj
+++ b/src/Spottarr.Services/Spottarr.Services.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4"/>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4"/>
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
-    <PackageReference Include="Spottarr.Usenet" Version="4.0.0-beta.*" />
+    <PackageReference Include="Spottarr.Usenet" Version="4.0.1"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Spottarr.Web/Program.cs
+++ b/src/Spottarr.Web/Program.cs
@@ -1,11 +1,8 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.FileProviders;
-using Spottarr.Data;
 using Spottarr.Data.Helpers;
 using Spottarr.Services;
 using Spottarr.Services.Helpers;
-using Spottarr.Web.Logging;
 using Spottarr.Web.Middlewares;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -32,7 +29,7 @@ if (builder.Environment.IsDevelopment() || builder.Environment.IsContainerFastMo
 
     foreach (var json in builder.Configuration.Sources.OfType<JsonConfigurationSource>())
         json.FileProvider = new PhysicalFileProvider(root);
-    
+
     if (builder.Configuration is IConfigurationRoot configRoot)
         configRoot.Reload();
 }
@@ -48,14 +45,7 @@ builder.Services.AddSpottarrServices(builder.Configuration);
 
 var app = builder.Build();
 
-await using (var scope = app.Services.CreateAsyncScope())
-{
-    var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
-    logger.DatabaseMigrationStarted(DbPathHelper.GetDbPath());
-    var dbContext = scope.ServiceProvider.GetRequiredService<SpottarrDbContext>();
-    await dbContext.Database.MigrateAsync();
-    logger.DatabaseMigrationFinished();
-}
+await app.MigrateDatabase();
 
 app.UseHttpsRedirection();
 app.UseDefaultFiles();


### PR DESCRIPTION
This PR implements a binary search algorithm to find the closest NNTP article number for a specific date. This way it's not required to fetch every header starting from the group's first article to find the correct date from which to start importing spots.